### PR TITLE
convenience method to retrieve seed as hex string

### DIFF
--- a/lib/money-tree/node.rb
+++ b/lib/money-tree/node.rb
@@ -289,5 +289,9 @@ module MoneyTree
       @chain_code = right_from_hash(seed_hash)
       @public_key = MoneyTree::PublicKey.new @private_key
     end
+
+    def seed_hex
+      bytes_to_hex(seed)
+    end
   end
 end

--- a/spec/lib/money-tree/node_spec.rb
+++ b/spec/lib/money-tree/node_spec.rb
@@ -11,6 +11,11 @@ describe MoneyTree::Master do
       it "generates a random seed 32 bytes long" do
         @master.seed.bytesize.should == 32
       end
+
+      it "exports the seed in hex format" do
+        @master.should respond_to(:seed_hex)
+        @master.seed_hex.size.should == 64
+      end
     end
 
     context "testnet" do


### PR DESCRIPTION
This would make it easier to backup the seed by exporting the seed in a non-binary format.
