### PR TITLE
preserve leading zeroes when exporting private key to hex/wif

### DIFF
--- a/lib/money-tree/support.rb
+++ b/lib/money-tree/support.rb
@@ -98,7 +98,7 @@ module MoneyTree
     def int_to_hex(i)
       hex = i.to_s(16)
       hex = '0' + hex unless (hex.length % 2).zero?
-      hex.downcase
+      hex.downcase.rjust(64, '0')
     end
         
     def int_to_bytes(i)

--- a/spec/lib/money-tree/private_key_spec.rb
+++ b/spec/lib/money-tree/private_key_spec.rb
@@ -6,9 +6,11 @@ describe MoneyTree::PrivateKey do
   end
   
   describe "to_hex" do
-    it "has 62 - 64 characters" do
-      # could be only 31 bytes if key has leading zeros
-      [62, 64].should include(@key.to_hex.length)
+    it "has 64 characters" do
+      # must always be 64 characters - leading zeroes need to be preserved!
+      @key.to_hex.length.should == 64
+      master = MoneyTree::Master.new seed_hex: "9cf6b6e8451c7d551cb402e2997566e5c7c258543eadb184f9f39322b2e6959b"
+      master.node_for_path("m/427").private_key.to_hex.length.should == 64
     end
     
     it "is a valid hex" do


### PR DESCRIPTION
otherwise keys starting with a zero would end up having a different address when imported somewhere else.

Tested against  the Bitcoin::Key library in bitcoin-ruby and electrum's import feature.

Not sure if this is the best way to fix it, since #int_to_hex is also used for other things that might be <64 chars - but at least it doesn't break the tests.

PS: I was able to reclaim the stuck funds by manually prepending "00" to the exported hex, before importing it into bitcoin-ruby.

PPS: Also thanks a lot for the library in the first place - I was really thrilled when I first saw it! :)
