### PR TITLE
Remove network state

### DIFF
--- a/lib/money-tree/address.rb
+++ b/lib/money-tree/address.rb
@@ -8,8 +8,8 @@ module MoneyTree
       @public_key = MoneyTree::PublicKey.new(@private_key, opts)
     end
     
-    def to_s
-      public_key.to_s
+    def to_s(network: :bitcoin)
+      public_key.to_s(network: network)
     end
 
   end

--- a/lib/money-tree/key.rb
+++ b/lib/money-tree/key.rb
@@ -13,10 +13,10 @@ module MoneyTree
     class KeyFormatNotFound < Exception; end
     class InvalidWIFFormat < Exception; end
     class InvalidBase64Format < Exception; end
-    
+
     attr_reader :options, :key, :raw_key
     attr_accessor :ec_key
-    
+
     GROUP_NAME = 'secp256k1'
     ORDER = "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141".to_i(16)
 
@@ -24,18 +24,18 @@ module MoneyTree
       eckey ||= ec_key
       eckey.nil? ? false : eckey.check_key
     end
-    
+
     def to_bytes
       hex_to_bytes to_hex
     end
-    
+
     def to_i
       bytes_to_int to_bytes
     end
   end
-  
+
   class PrivateKey < Key
-        
+
     def initialize(opts = {})
       @options = opts
       @ec_key = PKey::EC.new GROUP_NAME
@@ -48,34 +48,34 @@ module MoneyTree
         @key = to_hex
       end
     end
-    
+
     def generate
       ec_key.generate_key
     end
-    
+
     def import
       ec_key.private_key = BN.new(key, 16)
       set_public_key
     end
-    
+
     def calculate_public_key(opts = {})
       opts[:compressed] = true unless opts[:compressed] == false
       group = ec_key.group
       group.point_conversion_form = opts[:compressed] ? :compressed : :uncompressed
       point = group.generator.mul ec_key.private_key
     end
-    
+
     def set_public_key(opts = {})
       ec_key.public_key = calculate_public_key(opts)
     end
-    
+
     def parse_raw_key
       result = if raw_key.is_a?(Bignum) then from_bignum
       elsif hex_format? then from_hex
       elsif base64_format? then from_base64
       elsif compressed_wif_format? then from_wif
       elsif uncompressed_wif_format? then from_wif
-      else 
+      else
         raise KeyFormatNotFound
       end
       result.downcase
@@ -89,7 +89,7 @@ module MoneyTree
     def from_hex(hex = raw_key)
       hex
     end
-    
+
     def from_wif(wif = raw_key)
       compressed = wif.length == 52
       validate_wif(wif)
@@ -106,7 +106,7 @@ module MoneyTree
     def compressed_wif_format?
       wif_format?(:compressed)
     end
-    
+
     def uncompressed_wif_format?
       wif_format?(:uncompressed)
     end
@@ -120,15 +120,15 @@ module MoneyTree
     def base64_format?(base64_key = raw_key)
       base64_key.length == 44 && base64_key =~ /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/
     end
-    
+
     def hex_format?
       raw_key.length == 64 && !raw_key[/\H/]
     end
-    
+
     def to_hex
       int_to_hex @ec_key.private_key, 64
     end
-    
+
     def to_wif(compressed: true, network: :bitcoin)
       source = NETWORKS[network][:privkey_version] + to_hex
       source += NETWORKS[network][:privkey_compression_flag] if compressed
@@ -148,24 +148,24 @@ module MoneyTree
       hash_checksum = hash.slice(0..7)
       checksum == hash_checksum
     end
-    
+
     def validate_wif(wif)
       raise InvalidWIFFormat unless wif_valid?(wif)
     end
-    
+
     def to_base64
       encode_base64(to_hex)
     end
-    
+
     def to_s(network: :bitcoin)
       to_wif(network: network)
     end
-    
+
   end
-  
+
   class PublicKey < Key
     attr_reader :private_key, :point, :group, :key_int
-    
+
     def initialize(p_key, opts = {})
       @options = opts
       @options[:compressed] = true if @options[:compressed].nil?
@@ -182,27 +182,27 @@ module MoneyTree
 
       raise ArgumentError, "Must initialize with a MoneyTree::PrivateKey or a public key value" if @key.nil?
     end
-    
+
     def compression
       @group.point_conversion_form
     end
-    
+
     def compression=(compression_type = :compressed)
       @group.point_conversion_form = compression_type
     end
-    
+
     def compressed
       compressed_key = self.class.new raw_key, options # deep clone
       compressed_key.set_point to_i, compressed: true
       compressed_key
     end
-    
+
     def uncompressed
       uncompressed_key = self.class.new raw_key, options # deep clone
       uncompressed_key.set_point to_i, compressed: false
       uncompressed_key
     end
-    
+
     def set_point(int = to_i, opts = {})
       opts = options.merge(opts)
       opts[:compressed] = true if opts[:compressed].nil?
@@ -211,7 +211,7 @@ module MoneyTree
       @point = PKey::EC::Point.new group, bn
       raise KeyInvalid, 'point is not on the curve' unless @point.on_curve?
     end
-    
+
     def parse_raw_key
       result = if raw_key.is_a?(Bignum)
         set_point raw_key
@@ -219,45 +219,45 @@ module MoneyTree
         set_point hex_to_int(raw_key), compressed: false
       elsif compressed_hex_format?
         set_point hex_to_int(raw_key), compressed: true
-      else 
+      else
         raise KeyFormatNotFound
       end
       to_hex
     end
-    
+
     def hex_format?
       raw_key.length == 130 && !raw_key[/\H/]
     end
-    
+
     def compressed_hex_format?
       raw_key.length == 66 && !raw_key[/\H/]
     end
-    
+
     def to_hex
       int_to_hex to_i, 66
     end
-    
+
     def to_i
       point.to_bn.to_i
     end
-    
+
     def to_ripemd160
       hash = sha256 to_hex
       ripemd160 hash
     end
-    
+
     def to_address(network: :bitcoin)
       hash = to_ripemd160
       address = NETWORKS[network][:address_version] + hash
       to_serialized_base58 address
     end
     alias :to_s :to_address
-    
+
     def to_fingerprint
       hash = to_ripemd160
       hash.slice(0..7)
     end
-    
+
     def to_bytes
       int_to_bytes to_i
     end

--- a/lib/money-tree/networks.rb
+++ b/lib/money-tree/networks.rb
@@ -1,28 +1,33 @@
 module MoneyTree
-  NETWORKS = {
-    bitcoin: {
-      address_version: '00',
-      p2sh_version: '05',
-      p2sh_char: '3',
-      privkey_version: '80',
-      privkey_compression_flag: '01',
-      extended_privkey_version: "0488ade4",
-      extended_pubkey_version: "0488b21e",
-      compressed_wif_chars: %w(K L),
-      uncompressed_wif_chars: %w(5),
-      protocol_version: 70001
-    },
-    bitcoin_testnet: {
-      address_version: '6f',
-      p2sh_version: 'c4',
-      p2sh_char: '2',
-      privkey_version: 'ef',
-      privkey_compression_flag: '01',
-      extended_privkey_version: "04358394",
-      extended_pubkey_version: "043587cf",
-      compressed_wif_chars: %w(c),
-      uncompressed_wif_chars: %w(9),
-      protocol_version: 70001
-    }
-  }
+  NETWORKS = 
+    begin 
+      Hash.new do |_, key|
+        raise "#{key} is not a valid network!"
+      end.merge({
+        bitcoin: {
+          address_version: '00',
+          p2sh_version: '05',
+          p2sh_char: '3',
+          privkey_version: '80',
+          privkey_compression_flag: '01',
+          extended_privkey_version: "0488ade4",
+          extended_pubkey_version: "0488b21e",
+          compressed_wif_chars: %w(K L),
+          uncompressed_wif_chars: %w(5),
+          protocol_version: 70001
+        },
+        bitcoin_testnet: {
+          address_version: '6f',
+          p2sh_version: 'c4',
+          p2sh_char: '2',
+          privkey_version: 'ef',
+          privkey_compression_flag: '01',
+          extended_privkey_version: "04358394",
+          extended_pubkey_version: "043587cf",
+          compressed_wif_chars: %w(c),
+          uncompressed_wif_chars: %w(9),
+          protocol_version: 70001
+        }
+      })
+    end
 end

--- a/lib/money-tree/networks.rb
+++ b/lib/money-tree/networks.rb
@@ -1,9 +1,9 @@
 module MoneyTree
-  NETWORKS = 
-    begin 
-      Hash.new do |_, key|
+  NETWORKS =
+    begin
+      hsh = Hash.new do |_, key|
         raise "#{key} is not a valid network!"
-      end.merge({
+      end.merge(
         bitcoin: {
           address_version: '00',
           p2sh_version: '05',
@@ -28,6 +28,8 @@ module MoneyTree
           uncompressed_wif_chars: %w(9),
           protocol_version: 70001
         }
-      })
+      )
+      hsh[:testnet3] = hsh[:bitcoin_testnet]
+      hsh
     end
 end

--- a/lib/money-tree/node.rb
+++ b/lib/money-tree/node.rb
@@ -3,7 +3,7 @@ module MoneyTree
     include Support
     extend Support
     attr_reader :private_key, :public_key, :chain_code, 
-      :is_private, :depth, :index, :parent, :network, :network_key
+      :is_private, :depth, :index, :parent 
     
     class PublicDerivationFailure < Exception; end
     class InvalidKeyForIndex < Exception; end
@@ -11,49 +11,40 @@ module MoneyTree
     class PrivatePublicMismatch < Exception; end
     
     def initialize(opts = {})
-      @network_key = opts.delete(:network) || :bitcoin
-      @network = MoneyTree::NETWORKS[network_key]
       opts.each { |k, v| instance_variable_set "@#{k}", v }
     end
-    
-    def self.from_serialized_address(address)
+
+    def self.from_wif(address, has_version: true) 
       hex = from_serialized_base58 address
-      version = from_version_hex hex.slice!(0..7)
+      hex.slice!(0..7) if has_version
       self.new({
         depth: hex.slice!(0..1).to_i(16),
         parent_fingerprint: hex.slice!(0..7),
         index: hex.slice!(0..7).to_i(16),
         chain_code: hex.slice!(0..63).to_i(16)
-      }.merge(key_options(hex, version)))
+      }.merge(parse_out_key(hex)))
     end
-    
-    def self.key_options(hex, version)
-      k_opts = { network: version[:network] }
-      if version[:private_key] && hex.slice(0..1) == '00'
-        private_key = MoneyTree::PrivateKey.new({ key: hex.slice(2..-1) }.merge(k_opts))
-        k_opts.merge private_key: private_key, public_key: MoneyTree::PublicKey.new(private_key)
+
+    def self.from_serialized_address(address)
+      puts "Node.from_serialized_address is DEPRECATED.\n
+            Please use .from_wif instead."
+      from_wif(address)
+    end
+
+    def self.parse_out_key(hex)
+      if hex.slice(0..1) == '00'
+        private_key = MoneyTree::PrivateKey.new(key: hex.slice(2..-1))
+        { 
+          private_key: private_key,
+          public_key: MoneyTree::PublicKey.new(private_key) 
+        }
       elsif %w(02 03).include? hex.slice(0..1)
-        k_opts.merge public_key: MoneyTree::PublicKey.new(hex, k_opts)
+        { public_key: MoneyTree::PublicKey.new(hex) }
       else
         raise ImportError, 'Public or private key data does not match version type'
       end
     end
-    
-    def self.from_version_hex(hex)
-      case hex
-      when MoneyTree::NETWORKS[:bitcoin][:extended_privkey_version]
-        { private_key: true, network: :bitcoin }
-      when MoneyTree::NETWORKS[:bitcoin][:extended_pubkey_version]
-        { private_key: false, network: :bitcoin }
-      when MoneyTree::NETWORKS[:bitcoin_testnet][:extended_privkey_version]
-        { private_key: true, network: :bitcoin_testnet }
-      when MoneyTree::NETWORKS[:bitcoin_testnet][:extended_pubkey_version]
-        { private_key: false, network: :bitcoin_testnet }
-      else 
-        raise ImportError, 'invalid version bytes'
-      end
-    end
-    
+
     def is_private?
       index >= 0x80000000 || index < 0
     end
@@ -114,10 +105,10 @@ module MoneyTree
       bytes_to_int hash.bytes.to_a[32..-1]
     end
 
-    def to_serialized_hex(type = :public)
+    def to_serialized_hex(type = :public, network: :bitcoin)
       raise PrivatePublicMismatch if type.to_sym == :private && private_key.nil?
       version_key = type.to_sym == :private ? :extended_privkey_version : :extended_pubkey_version
-      hex = network[version_key] # version (4 bytes)
+      hex = NETWORKS[network][version_key] # version (4 bytes)
       hex += depth_hex(depth) # depth (1 byte)
       hex += parent_fingerprint # fingerprint of key (4 bytes)
       hex += index_hex(index) # child number i (4 bytes)
@@ -125,9 +116,9 @@ module MoneyTree
       hex += type.to_sym == :private ? "00#{private_key.to_hex}" : public_key.compressed.to_hex
     end
     
-    def to_serialized_address(type = :public)
+    def to_serialized_address(type = :public, network: :bitcoin)
       raise PrivatePublicMismatch if type.to_sym == :private && private_key.nil?
-      to_serialized_base58 to_serialized_hex(type)
+      to_serialized_base58 to_serialized_hex(type, network: network)
     end
 
     def to_identifier(compressed=true)
@@ -147,28 +138,27 @@ module MoneyTree
       end
     end
 
-    def to_address(compressed=true)
-      address = network[:address_version] + to_identifier(compressed)
+    def to_address(compressed=true, network: :bitcoin)
+      address = NETWORKS[network][:address_version] + to_identifier(compressed)
       to_serialized_base58 address
     end
     
     def subnode(i = 0, opts = {})
       if private_key.nil?
         child_public_key, child_chain_code = derive_public_key(i)
-        child_public_key = MoneyTree::PublicKey.new child_public_key, network: network_key
+        child_public_key = MoneyTree::PublicKey.new child_public_key
       else
         child_private_key, child_chain_code = derive_private_key(i)
-        child_private_key = MoneyTree::PrivateKey.new key: child_private_key, network: network_key
+        child_private_key = MoneyTree::PrivateKey.new key: child_private_key
         child_public_key = MoneyTree::PublicKey.new child_private_key
       end
             
-      MoneyTree::Node.new network: network_key,
-                          depth: depth+1, 
+      MoneyTree::Node.new( depth: depth+1, 
                           index: i, 
                           private_key: private_key.nil? ? nil : child_private_key,
                           public_key: child_public_key,
                           chain_code: child_chain_code,
-                          parent: self
+                          parent: self)
     end
     
     # path: a path of subkeys denoted by numbers and slashes. Use
@@ -246,8 +236,6 @@ module MoneyTree
       @depth = 0
       @index = 0
       opts[:seed] = [opts[:seed_hex]].pack("H*") if opts[:seed_hex]
-      @network_key = opts[:network] || :bitcoin
-      @network = MoneyTree::NETWORKS[network_key]
       if opts[:seed]
         @seed = opts[:seed]
         @seed_hash = generate_seed_hash(@seed)
@@ -258,14 +246,12 @@ module MoneyTree
         @chain_code = opts[:chain_code]
         if opts[:private_key]
           @private_key = opts[:private_key]
-          @network_key = @private_key.network_key
-          @network = MoneyTree::NETWORKS[network_key]
           @public_key = MoneyTree::PublicKey.new @private_key
         else opts[:public_key]
           @public_key = if opts[:public_key].is_a?(MoneyTree::PublicKey)
             opts[:public_key]
           else
-            MoneyTree::PublicKey.new(opts[:public_key], network: network_key)
+            MoneyTree::PublicKey.new(opts[:public_key])
           end
         end
       else
@@ -295,7 +281,7 @@ module MoneyTree
     end
     
     def set_seeded_keys
-      @private_key = MoneyTree::PrivateKey.new key: left_from_hash(seed_hash), network: network_key
+      @private_key = MoneyTree::PrivateKey.new key: left_from_hash(seed_hash)
       @chain_code = right_from_hash(seed_hash)
       @public_key = MoneyTree::PublicKey.new @private_key
     end

--- a/lib/money-tree/node.rb
+++ b/lib/money-tree/node.rb
@@ -2,19 +2,19 @@ module MoneyTree
   class Node
     include Support
     extend Support
-    attr_reader :private_key, :public_key, :chain_code, 
-      :is_private, :depth, :index, :parent 
-    
+    attr_reader :private_key, :public_key, :chain_code,
+      :is_private, :depth, :index, :parent
+
     class PublicDerivationFailure < Exception; end
     class InvalidKeyForIndex < Exception; end
     class ImportError < Exception; end
     class PrivatePublicMismatch < Exception; end
-    
+
     def initialize(opts = {})
       opts.each { |k, v| instance_variable_set "@#{k}", v }
     end
 
-    def self.from_bip32(address, has_version: true) 
+    def self.from_bip32(address, has_version: true)
       hex = from_serialized_base58 address
       hex.slice!(0..7) if has_version
       self.new({
@@ -33,9 +33,9 @@ module MoneyTree
     def self.parse_out_key(hex)
       if hex.slice(0..1) == '00'
         private_key = MoneyTree::PrivateKey.new(key: hex.slice(2..-1))
-        { 
+        {
           private_key: private_key,
-          public_key: MoneyTree::PublicKey.new(private_key) 
+          public_key: MoneyTree::PublicKey.new(private_key)
         }
       elsif %w(02 03).include? hex.slice(0..1)
         { public_key: MoneyTree::PublicKey.new(hex) }
@@ -47,7 +47,7 @@ module MoneyTree
     def is_private?
       index >= 0x80000000 || index < 0
     end
-    
+
     def index_hex(i = index)
       if i < 0
         [i].pack('l>').unpack('H*').first
@@ -55,15 +55,15 @@ module MoneyTree
         i.to_s(16).rjust(8, "0")
       end
     end
-    
+
     def depth_hex(depth)
       depth.to_s(16).rjust(2, "0")
     end
-    
+
     def private_derivation_message(i)
       "\x00" + private_key.to_bytes + i_as_bytes(i)
     end
-    
+
     def public_derivation_message(i)
       public_key.to_bytes << i_as_bytes(i)
     end
@@ -71,7 +71,7 @@ module MoneyTree
     def i_as_bytes(i)
       [i].pack('N')
     end
-    
+
     def derive_private_key(i = 0)
       message = i >= 0x80000000 || i < 0 ? private_derivation_message(i) : public_derivation_message(i)
       hash = hmac_sha512 hex_to_bytes(chain_code_hex), message
@@ -82,7 +82,7 @@ module MoneyTree
       child_chain_code = right_from_hash(hash)
       return child_private_key, child_chain_code
     end
-    
+
     def derive_public_key(i = 0)
       raise PrivatePublicMismatch if i >= 0x80000000
       message = public_derivation_message(i)
@@ -95,11 +95,11 @@ module MoneyTree
       child_chain_code = right_from_hash(hash)
       return child_public_key, child_chain_code
     end
-    
+
     def left_from_hash(hash)
       bytes_to_int hash.bytes.to_a[0..31]
     end
-    
+
     def right_from_hash(hash)
       bytes_to_int hash.bytes.to_a[32..-1]
     end
@@ -114,7 +114,7 @@ module MoneyTree
       hex += chain_code_hex
       hex += type.to_sym == :private ? "00#{private_key.to_hex}" : public_key.compressed.to_hex
     end
-    
+
     def to_bip32(type = :public, network: :bitcoin)
       raise PrivatePublicMismatch if type.to_sym == :private && private_key.nil?
       to_serialized_base58 to_serialized_hex(type, network: network)
@@ -129,11 +129,11 @@ module MoneyTree
       key = compressed ? public_key.compressed : public_key.uncompressed
       key.to_ripemd160
     end
-    
+
     def to_fingerprint
       public_key.compressed.to_fingerprint
     end
-    
+
     def parent_fingerprint
       if @parent_fingerprint
         @parent_fingerprint
@@ -146,7 +146,7 @@ module MoneyTree
       address = NETWORKS[network][:address_version] + to_identifier(compressed)
       to_serialized_base58 address
     end
-    
+
     def subnode(i = 0, opts = {})
       if private_key.nil?
         child_public_key, child_chain_code = derive_public_key(i)
@@ -156,25 +156,25 @@ module MoneyTree
         child_private_key = MoneyTree::PrivateKey.new key: child_private_key
         child_public_key = MoneyTree::PublicKey.new child_private_key
       end
-            
-      MoneyTree::Node.new( depth: depth+1, 
-                          index: i, 
+
+      MoneyTree::Node.new( depth: depth+1,
+                          index: i,
                           private_key: private_key.nil? ? nil : child_private_key,
                           public_key: child_public_key,
                           chain_code: child_chain_code,
                           parent: self)
     end
-    
+
     # path: a path of subkeys denoted by numbers and slashes. Use
     #     p or i<0 for private key derivation. End with .pub to force
     #     the key public.
-    # 
+    #
     # Examples:
     #     1p/-5/2/1 would call subkey(i=1, is_prime=True).subkey(i=-5).
     #         subkey(i=2).subkey(i=1) and then yield the private key
     #     0/0/458.pub would call subkey(i=0).subkey(i=0).subkey(i=458) and
     #         then yield the public key
-    # 
+    #
     # You should choose either the p or the negative number convention for private key derivation.
     def node_for_path(path)
       force_public = path[-4..-1] == '.pub'
@@ -198,11 +198,11 @@ module MoneyTree
         nodes.last
       end
     end
-    
+
     def parse_index(path_part)
       is_prime = %w(p ').include? path_part[-1]
       i = path_part.to_i
-      
+
       i = if i < 0
         i
       elsif is_prime
@@ -211,16 +211,16 @@ module MoneyTree
         i & 0x7fffffff
       end
     end
-    
+
     def strip_private_info!
       @private_key = nil
     end
-    
+
     def chain_code_hex
       int_to_hex chain_code, 64
     end
   end
-  
+
   class Master < Node
     module SeedGeneration
       class Failure < Exception; end
@@ -230,12 +230,12 @@ module MoneyTree
       class ImportError < Failure; end
       class TooManyAttempts < Failure; end
     end
-    
+
     HD_WALLET_BASE_KEY = "Bitcoin seed"
     RANDOM_SEED_SIZE = 32
-    
+
     attr_reader :seed, :seed_hash
-    
+
     def initialize(opts = {})
       @depth = 0
       @index = 0
@@ -263,27 +263,27 @@ module MoneyTree
         set_seeded_keys
       end
     end
-    
+
     def is_private?
       true
     end
-    
+
     def generate_seed
       @seed = OpenSSL::Random.random_bytes(32)
       @seed_hash = generate_seed_hash(@seed)
       raise SeedGeneration::ValidityError unless seed_valid?(@seed_hash)
     end
-    
+
     def generate_seed_hash(seed)
       hmac_sha512 HD_WALLET_BASE_KEY, seed
     end
-    
+
     def seed_valid?(seed_hash)
       return false unless seed_hash.bytesize == 64
       master_key = left_from_hash(seed_hash)
       !master_key.zero? && master_key < MoneyTree::Key::ORDER
     end
-    
+
     def set_seeded_keys
       @private_key = MoneyTree::PrivateKey.new key: left_from_hash(seed_hash)
       @chain_code = right_from_hash(seed_hash)

--- a/lib/money-tree/node.rb
+++ b/lib/money-tree/node.rb
@@ -14,7 +14,7 @@ module MoneyTree
       opts.each { |k, v| instance_variable_set "@#{k}", v }
     end
 
-    def self.from_wif(address, has_version: true) 
+    def self.from_bip32(address, has_version: true) 
       hex = from_serialized_base58 address
       hex.slice!(0..7) if has_version
       self.new({
@@ -26,9 +26,8 @@ module MoneyTree
     end
 
     def self.from_serialized_address(address)
-      puts "Node.from_serialized_address is DEPRECATED.\n
-            Please use .from_wif instead."
-      from_wif(address)
+      puts 'Node.from_serialized_address is DEPRECATED. Please use .from_bip32 instead.'
+      from_bip32(address)
     end
 
     def self.parse_out_key(hex)
@@ -116,9 +115,14 @@ module MoneyTree
       hex += type.to_sym == :private ? "00#{private_key.to_hex}" : public_key.compressed.to_hex
     end
     
-    def to_serialized_address(type = :public, network: :bitcoin)
+    def to_bip32(type = :public, network: :bitcoin)
       raise PrivatePublicMismatch if type.to_sym == :private && private_key.nil?
       to_serialized_base58 to_serialized_hex(type, network: network)
+    end
+
+    def to_serialized_address(type = :public, network: :bitcoin)
+      puts 'Node.to_serialized_address is DEPRECATED. Please use .to_bip32.'
+      to_bip32(type, network: network)
     end
 
     def to_identifier(compressed=true)

--- a/spec/lib/money-tree/address_spec.rb
+++ b/spec/lib/money-tree/address_spec.rb
@@ -56,7 +56,7 @@ describe MoneyTree::Address do
     end
 
     it "returns a testnet address" do
-      expect(%w(m n)).to include(@address.to_s[0])
+      expect(%w(m n)).to include(@address.to_s(network: :bitcoin_testnet)[0])
     end
   end
 end

--- a/spec/lib/money-tree/node_spec.rb
+++ b/spec/lib/money-tree/node_spec.rb
@@ -24,49 +24,49 @@ describe MoneyTree::Master do
       end
 
       it "generates testnet address" do
-        expect(%w(m n)).to include(@master.to_address[0])
+        expect(%w(m n)).to include(@master.to_address(network: :bitcoin_testnet)[0])
       end
 
       it "generates testnet compressed wif" do
-        expect(@master.private_key.to_wif[0]).to eql('c')
+        expect(@master.private_key.to_wif(network: :bitcoin_testnet)[0]).to eql('c')
       end
 
       it "generates testnet uncompressed wif" do
-        expect(@master.private_key.to_wif(compressed: false)[0]).to eql('9')
+        expect(@master.private_key.to_wif(compressed: false, network: :bitcoin_testnet)[0]).to eql('9')
       end
 
       it "generates testnet serialized private address" do
-        expect(@master.to_serialized_address(:private).slice(0, 4)).to eql("tprv")
+        expect(@master.to_serialized_address(:private, network: :bitcoin_testnet).slice(0, 4)).to eql("tprv")
       end
 
       it "generates testnet serialized public address" do
-        expect(@master.to_serialized_address.slice(0, 4)).to eql("tpub")
+        expect(@master.to_serialized_address(network: :bitcoin_testnet).slice(0, 4)).to eql("tpub")
       end
 
       it "imports from testnet serialized private address" do
         node = MoneyTree::Node.from_serialized_address 'tprv8ZgxMBicQKsPcuN7bfUZqq78UEYapr3Tzmc9NcDXw8BnBJ47dZYr6SusnfYj7vbAYP9CP8ZiD5aVBTUo1yU5QP56mepKVvuEbu8KZQXMKNE'
-        expect(node.to_serialized_address(:private)).to eql('tprv8ZgxMBicQKsPcuN7bfUZqq78UEYapr3Tzmc9NcDXw8BnBJ47dZYr6SusnfYj7vbAYP9CP8ZiD5aVBTUo1yU5QP56mepKVvuEbu8KZQXMKNE')
+        expect(node.to_serialized_address(:private, network: :bitcoin_testnet)).to eql('tprv8ZgxMBicQKsPcuN7bfUZqq78UEYapr3Tzmc9NcDXw8BnBJ47dZYr6SusnfYj7vbAYP9CP8ZiD5aVBTUo1yU5QP56mepKVvuEbu8KZQXMKNE')
       end
 
       it "imports from testnet serialized public address" do
         node = MoneyTree::Node.from_serialized_address 'tpubD6NzVbkrYhZ4YA8aUE9bBZTSyHJibBqwDny5urfwDdJc4W8od3y3Ebzy6CqsYn9CCC5P5VQ7CeZYpnT1kX3RPVPysU2rFRvYSj8BCoYYNqT'
-        expect(%w(m n)).to include(node.public_key.to_s[0])
-        expect(node.to_serialized_address).to eql('tpubD6NzVbkrYhZ4YA8aUE9bBZTSyHJibBqwDny5urfwDdJc4W8od3y3Ebzy6CqsYn9CCC5P5VQ7CeZYpnT1kX3RPVPysU2rFRvYSj8BCoYYNqT')
+        expect(%w(m n)).to include(node.public_key.to_s(network: :bitcoin_testnet)[0])
+        expect(node.to_serialized_address(network: :bitcoin_testnet)).to eql('tpubD6NzVbkrYhZ4YA8aUE9bBZTSyHJibBqwDny5urfwDdJc4W8od3y3Ebzy6CqsYn9CCC5P5VQ7CeZYpnT1kX3RPVPysU2rFRvYSj8BCoYYNqT')
       end
 
       it "generates testnet subnodes from serialized private address" do
         node = MoneyTree::Node.from_serialized_address 'tprv8ZgxMBicQKsPcuN7bfUZqq78UEYapr3Tzmc9NcDXw8BnBJ47dZYr6SusnfYj7vbAYP9CP8ZiD5aVBTUo1yU5QP56mepKVvuEbu8KZQXMKNE'
         subnode = node.node_for_path('1/1/1')
-        expect(%w(m n)).to include(subnode.public_key.to_s[0])
-        expect(subnode.to_serialized_address(:private).slice(0,4)).to eql('tprv')
-        expect(subnode.to_serialized_address.slice(0,4)).to eql('tpub')
+        expect(%w(m n)).to include(subnode.public_key.to_s(network: :bitcoin_testnet)[0])
+        expect(subnode.to_serialized_address(:private, network: :bitcoin_testnet).slice(0,4)).to eql('tprv')
+        expect(subnode.to_serialized_address(network: :bitcoin_testnet).slice(0,4)).to eql('tpub')
       end
 
       it "generates testnet subnodes from serialized public address" do
         node = MoneyTree::Node.from_serialized_address 'tpubD6NzVbkrYhZ4YA8aUE9bBZTSyHJibBqwDny5urfwDdJc4W8od3y3Ebzy6CqsYn9CCC5P5VQ7CeZYpnT1kX3RPVPysU2rFRvYSj8BCoYYNqT'
         subnode = node.node_for_path('1/1/1')
-        expect(%w(m n)).to include(subnode.public_key.to_s[0])
-        expect(subnode.to_serialized_address.slice(0,4)).to eql('tpub')
+        expect(%w(m n)).to include(subnode.public_key.to_s(network: :bitcoin_testnet)[0])
+        expect(subnode.to_serialized_address(network: :bitcoin_testnet).slice(0,4)).to eql('tpub')
       end
     end
 
@@ -799,7 +799,7 @@ describe MoneyTree::Master do
         it "correctly derives from a node with a chain code represented in 31 bytes" do
           @node = MoneyTree::Node.from_serialized_address "tpubD6NzVbkrYhZ4WM42MZZmUZ7LjxyjBf5bGjEeLf9nJnMZqocGJWu94drvpqWsE9jE7k3h22v6gjpPGnqgBrqwGsRYwDXVRfQ2M9dfHbXP5zA"
           @subnode = @node.node_for_path('m/1')
-          expect(@subnode.to_serialized_address).to eql("tpubDA7bCxb3Nrcz2ChXyPqXxbG4q5oiAZUHR7wD3LAiXukuxmT65weWw84XYmjhkJTkJEM6LhNWioWTpKEkQp7j2fgVccj3PPc271xHDeMsaTY")
+          expect(@subnode.to_serialized_address(network: :bitcoin_testnet)).to eql("tpubDA7bCxb3Nrcz2ChXyPqXxbG4q5oiAZUHR7wD3LAiXukuxmT65weWw84XYmjhkJTkJEM6LhNWioWTpKEkQp7j2fgVccj3PPc271xHDeMsaTY")
         end
       end
     end

--- a/spec/lib/money-tree/private_key_spec.rb
+++ b/spec/lib/money-tree/private_key_spec.rb
@@ -45,7 +45,7 @@ describe MoneyTree::PrivateKey do
     end
     
     it "is valid" do
-      expect(@key.to_wif(compressed: false)).to eql('5JXz5ZyFk31oHVTQxqce7yitCmTAPxBqeGQ4b7H3Aj3L45wUhoa'      )
+      expect(@key.to_wif(compressed: false)).to eql('5JXz5ZyFk31oHVTQxqce7yitCmTAPxBqeGQ4b7H3Aj3L45wUhoa')
     end
   end
   
@@ -104,7 +104,7 @@ describe MoneyTree::PrivateKey do
 
     describe "to_wif" do
       it "returns same wif" do
-        expect(@key.to_wif).to eql('cRhes8SBnsF6WizphaRKQKZZfDniDa9Bxcw31yKeEC1KDExhxFgD')
+        expect(@key.to_wif(network: :bitcoin_testnet)).to eql('cRhes8SBnsF6WizphaRKQKZZfDniDa9Bxcw31yKeEC1KDExhxFgD')
       end
     end
   end

--- a/spec/lib/money-tree/public_key_spec.rb
+++ b/spec/lib/money-tree/public_key_spec.rb
@@ -161,26 +161,26 @@ describe MoneyTree::PublicKey do
   context "testnet" do
     context 'with private key' do
       before do
-        @private_key = MoneyTree::PrivateKey.new network: :bitcoin_testnet
+        @private_key = MoneyTree::PrivateKey.new
         @key = MoneyTree::PublicKey.new(@private_key)
       end
 
       it "should have an address starting with m or n" do
-        expect(%w(m n)).to include(@key.to_s[0])
+        expect(%w(m n)).to include(@key.to_s(network: :bitcoin_testnet)[0])
       end
 
       it "should have an uncompressed address starting with m or n" do
-        expect(%w(m n)).to include(@key.uncompressed.to_s[0])
+        expect(%w(m n)).to include(@key.uncompressed.to_s(network: :bitcoin_testnet)[0])
       end
     end
 
     context 'without private key' do
       before do
-        @key = MoneyTree::PublicKey.new('0297b033ba894611345a0e777861237ef1632370fbd58ebe644eb9f3714e8fe2bc', network: :bitcoin_testnet)
+        @key = MoneyTree::PublicKey.new('0297b033ba894611345a0e777861237ef1632370fbd58ebe644eb9f3714e8fe2bc')
       end
 
       it "should have an address starting with m or n" do
-        expect(%w(m n)).to include(@key.to_s[0])
+        expect(%w(m n)).to include(@key.to_s(network: :bitcoin_testnet)[0])
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require 'simplecov'
 require 'money-tree'
+require 'pry'


### PR DESCRIPTION
Money-Tree, in essence is a key-derivation tool.
The keys it derives are not aware of the 'coin',
or 'version'. So there is now no notion of network
held as state on anything.

Money-Tree derives keys, and in the various forms of serialization
you can specify which type of coin (version bytes) you'd like to use.

Although it may seem tedious, it allows trees to be
coin-agnostic until serialization (and theoretically
the usage of the same key-pairs for different coin
addresses.)