### PR TITLE
[Fix] Descend From StandardError Not Exception

### DIFF
--- a/lib/money-tree/key.rb
+++ b/lib/money-tree/key.rb
@@ -7,12 +7,12 @@ module MoneyTree
     include OpenSSL
     include Support
     extend Support
-    class KeyInvalid < Exception; end
-    class KeyGenerationFailure < Exception; end
-    class KeyImportFailure < Exception; end
-    class KeyFormatNotFound < Exception; end
-    class InvalidWIFFormat < Exception; end
-    class InvalidBase64Format < Exception; end
+    class KeyInvalid < StandardError; end
+    class KeyGenerationFailure < StandardError; end
+    class KeyImportFailure < StandardError; end
+    class KeyFormatNotFound < StandardError; end
+    class InvalidWIFFormat < StandardError; end
+    class InvalidBase64Format < StandardError; end
 
     attr_reader :options, :key, :raw_key
     attr_accessor :ec_key

--- a/lib/money-tree/node.rb
+++ b/lib/money-tree/node.rb
@@ -5,10 +5,10 @@ module MoneyTree
     attr_reader :private_key, :public_key, :chain_code,
       :is_private, :depth, :index, :parent
 
-    class PublicDerivationFailure < Exception; end
-    class InvalidKeyForIndex < Exception; end
-    class ImportError < Exception; end
-    class PrivatePublicMismatch < Exception; end
+    class PublicDerivationFailure < StandardError; end
+    class InvalidKeyForIndex < StandardError; end
+    class ImportError < StandardError; end
+    class PrivatePublicMismatch < StandardError; end
 
     def initialize(opts = {})
       opts.each { |k, v| instance_variable_set "@#{k}", v }

--- a/spec/lib/money-tree/private_key_spec.rb
+++ b/spec/lib/money-tree/private_key_spec.rb
@@ -93,7 +93,17 @@ describe MoneyTree::PrivateKey do
   describe "parse_raw_key" do
     it "returns error if key is not Bignum, hex, base64, or wif formatted" do
       expect { @key = MoneyTree::PrivateKey.new(key: "Thisisnotakey") }.to raise_error(MoneyTree::Key::KeyFormatNotFound)
-      
+    end
+
+    it "raises an error that can be caught using a standard exception block" do
+      exception_raised = false
+
+      begin
+        MoneyTree::PrivateKey.new(key: "Thisisnotakey")
+      rescue => ex
+        exception_raised = true
+      end
+      fail unless exception_raised
     end
   end
 


### PR DESCRIPTION
**What changed?**
* Have all internal exceptions descend from `StandardError` rather than `Exception`.

**Why?**
* This is a Ruby gotcha (see link below). Essentially using `rescue => e` will not catch any of
  these exceptions as this only catches subclasses of `StandardError`. This can cause users of the
  library to get unexpected results when implementing error handling this way.

**References**
[Rescue StandardError, Not Exception](https://robots.thoughtbot.com/rescue-standarderror-not-exception)