### PR TITLE
Support more libssl library names so this will work on heroku

### DIFF
--- a/lib/openssl_extensions.rb
+++ b/lib/openssl_extensions.rb
@@ -6,7 +6,7 @@ require 'ffi'
 module MoneyTree
   module OpenSSLExtensions
     extend FFI::Library
-    ffi_lib 'ssl'
+    ffi_lib ['libssl.so.1.0.0', 'libssl.so.10', 'ssl']
 
     NID_secp256k1 = 714
     POINT_CONVERSION_COMPRESSED = 2


### PR DESCRIPTION
Hi, this is a really simple fix that makes money-tree work on more platforms with different libssl names.  For example, on heroku, the library is called libssl.so.1.0.0.

This small change keeps backwards compatibility :)