### PR TITLE
added configuration for network, default mainnet

### DIFF
--- a/lib/money-tree.rb
+++ b/lib/money-tree.rb
@@ -1,4 +1,5 @@
 require "openssl_extensions"
+require 'money-tree/configuration'
 require "money-tree/version"
 require "money-tree/support"
 require "money-tree/networks"
@@ -8,5 +9,23 @@ require "money-tree/networks"
 require "money-tree/node"
 
 module MoneyTree
-  
+  class << self
+     attr_accessor :configuration
+   end
+
+   def self.network
+     configuration.network
+   end
+
+   def self.configuration
+     @configuration ||= Configuration.new
+   end
+
+   def self.reset
+     @configuration = Configuration.new
+   end
+
+   def self.configure
+     yield(configuration)
+   end
 end

--- a/lib/money-tree/address.rb
+++ b/lib/money-tree/address.rb
@@ -1,14 +1,15 @@
 module MoneyTree
   class Address
     attr_reader :private_key, :public_key
-    
+
     def initialize(opts = {})
       private_key = opts.delete(:private_key)
       @private_key = MoneyTree::PrivateKey.new({ key: private_key }.merge(opts))
       @public_key = MoneyTree::PublicKey.new(@private_key, opts)
     end
-    
-    def to_s(network: :bitcoin)
+
+    def to_s(network: nil)
+      network ||= MoneyTree.network
       public_key.to_s(network: network)
     end
 

--- a/lib/money-tree/configuration.rb
+++ b/lib/money-tree/configuration.rb
@@ -1,0 +1,9 @@
+module MoneyTree
+  class Configuration
+   attr_accessor :network
+
+   def initialize(args={})
+     @network = args.delete(:network) || :bitcoin
+   end
+ end
+end

--- a/lib/money-tree/key.rb
+++ b/lib/money-tree/key.rb
@@ -129,7 +129,8 @@ module MoneyTree
       int_to_hex @ec_key.private_key, 64
     end
 
-    def to_wif(compressed: true, network: :bitcoin)
+    def to_wif(compressed: true, network: nil)
+      network ||= MoneyTree.network
       source = NETWORKS[network][:privkey_version] + to_hex
       source += NETWORKS[network][:privkey_compression_flag] if compressed
       hash = sha256(source)
@@ -157,7 +158,8 @@ module MoneyTree
       encode_base64(to_hex)
     end
 
-    def to_s(network: :bitcoin)
+    def to_s(network: nil)
+      network ||= MoneyTree.network
       to_wif(network: network)
     end
 
@@ -246,7 +248,8 @@ module MoneyTree
       ripemd160 hash
     end
 
-    def to_address(network: :bitcoin)
+    def to_address(network: nil)
+      network ||= MoneyTree.network
       hash = to_ripemd160
       address = NETWORKS[network][:address_version] + hash
       to_serialized_base58 address

--- a/lib/money-tree/node.rb
+++ b/lib/money-tree/node.rb
@@ -104,8 +104,9 @@ module MoneyTree
       bytes_to_int hash.bytes.to_a[32..-1]
     end
 
-    def to_serialized_hex(type = :public, network: :bitcoin)
+    def to_serialized_hex(type = :public, network: nil)
       raise PrivatePublicMismatch if type.to_sym == :private && private_key.nil?
+      network ||= MoneyTree.network
       version_key = type.to_sym == :private ? :extended_privkey_version : :extended_pubkey_version
       hex = NETWORKS[network][version_key] # version (4 bytes)
       hex += depth_hex(depth) # depth (1 byte)
@@ -115,12 +116,14 @@ module MoneyTree
       hex += type.to_sym == :private ? "00#{private_key.to_hex}" : public_key.compressed.to_hex
     end
 
-    def to_bip32(type = :public, network: :bitcoin)
+    def to_bip32(type = :public, network: nil)
       raise PrivatePublicMismatch if type.to_sym == :private && private_key.nil?
+      network ||= MoneyTree.network
       to_serialized_base58 to_serialized_hex(type, network: network)
     end
 
-    def to_serialized_address(type = :public, network: :bitcoin)
+    def to_serialized_address(type = :public, network: nil)
+      network ||= MoneyTree.network
       puts 'Node.to_serialized_address is DEPRECATED. Please use .to_bip32.'
       to_bip32(type, network: network)
     end
@@ -142,7 +145,8 @@ module MoneyTree
       end
     end
 
-    def to_address(compressed=true, network: :bitcoin)
+    def to_address(compressed=true, network: nil)
+      network ||= MoneyTree.network
       address = NETWORKS[network][:address_version] + to_identifier(compressed)
       to_serialized_base58 address
     end


### PR DESCRIPTION
Based on my Issue https://github.com/GemHQ/money-tree/issues/33 the following pull request

adds ability to set the network globally

    MoneyTree.configure do |config|
      config.network = :testnet3
    end

default will be `:bitcoin` as before

tests are all passing. nothing was changed, only added. 