### PR TITLE
Fix OpenSSL lib loading for ruby 2.6.5 (fixes #38)

### DIFF
--- a/lib/money-tree/version.rb
+++ b/lib/money-tree/version.rb
@@ -1,3 +1,3 @@
 module MoneyTree
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end

--- a/lib/openssl_extensions.rb
+++ b/lib/openssl_extensions.rb
@@ -6,7 +6,7 @@ require 'ffi'
 module MoneyTree
   module OpenSSLExtensions
     extend FFI::Library
-    ffi_lib ['libssl.so.1.0.0', 'libssl.so.10', 'libssl1.0.0', 'ssl']
+    ffi_lib ['libssl.so.1.0.0', 'libssl.so.10', 'libssl1.0.0', 'libssl.1.0.0', 'ssl']
 
     NID_secp256k1 = 714
     POINT_CONVERSION_COMPRESSED = 2


### PR DESCRIPTION
On MacOS the library is called `/usr/local/lib/libssl.1.0.0.dylib`, so current settings do not finally resolve it. Added support for it.

Actually found that [eth](https://rubygems.org/gems/eth) gem fails to load without that fix, because it depends on `money-tree`. Throws `Abort trap: 6` error message. And the package itself cannot be loaded because of this issue.