### PR TITLE
Fix private key immutability error when using OpenSSL 3.0 

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -28,7 +28,7 @@ jobs:
         sed -i '/^\default = default_sect/a legacy = legacy_sect' /etc/ssl/openssl.cnf
         sed -i '/^\[default_sect\]/a activate = 1' /etc/ssl/openssl.cnf
         echo "[legacy_sect]" >> /etc/ssl/openssl.cnf
-        echo "activate = 1" >> /etc/ssl/openssl.cnf
+        sudo echo "activate = 1" >> /etc/ssl/openssl.cnf
     - name: Install Dependencies
       run: |
         bundle install

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Load OpenSSL ripemd160
       run: |
         sudo sed -i '/^\default = default_sect/a legacy = legacy_sect' /etc/ssl/openssl.cnf
-        sed -i '/^\[default_sect\]/a activate = 1' /etc/ssl/openssl.cnf
+        sudo sed -i '/^\[default_sect\]/a activate = 1' /etc/ssl/openssl.cnf
         echo "[legacy_sect]" >> /etc/ssl/openssl.cnf
         sudo echo "activate = 1" >> /etc/ssl/openssl.cnf
     - name: Install Dependencies

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -25,7 +25,7 @@ jobs:
         bundler-cache: false
     - name: Load OpenSSL ripemd160
       run: |
-        sed -i '/^\default = default_sect/a legacy = legacy_sect' /etc/ssl/openssl.cnf
+        sudo sed -i '/^\default = default_sect/a legacy = legacy_sect' /etc/ssl/openssl.cnf
         sed -i '/^\[default_sect\]/a activate = 1' /etc/ssl/openssl.cnf
         echo "[legacy_sect]" >> /etc/ssl/openssl.cnf
         sudo echo "activate = 1" >> /etc/ssl/openssl.cnf

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -23,6 +23,12 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: false
+    - name: Load OpenSSL ripemd160
+      run: |
+        sed -i '/^\default = default_sect/a legacy = legacy_sect' /etc/ssl/openssl.cnf
+        sed -i '/^\[default_sect\]/a activate = 1' /etc/ssl/openssl.cnf
+        echo "[legacy_sect]" >> /etc/ssl/openssl.cnf
+        echo "activate = 1" >> /etc/ssl/openssl.cnf
     - name: Install Dependencies
       run: |
         bundle install

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         sudo sed -i '/^\default = default_sect/a legacy = legacy_sect' /etc/ssl/openssl.cnf
         sudo sed -i '/^\[default_sect\]/a activate = 1' /etc/ssl/openssl.cnf
-        echo "[legacy_sect]" >> /etc/ssl/openssl.cnf
+        sudo echo "[legacy_sect]" >> /etc/ssl/openssl.cnf
         sudo echo "activate = 1" >> /etc/ssl/openssl.cnf
     - name: Install Dependencies
       run: |

--- a/lib/money-tree/key.rb
+++ b/lib/money-tree/key.rb
@@ -39,31 +39,38 @@ module MoneyTree
   class PrivateKey < Key
     def initialize(opts = {})
       @options = opts
-      @ec_key = PKey::EC.new GROUP_NAME
+      generate
       if @options[:key]
         @raw_key = @options[:key]
         @key = parse_raw_key
         import
       else
-        generate
         @key = to_hex
       end
     end
 
     def generate
-      ec_key.generate_key
+      @ec_key = PKey::EC.generate GROUP_NAME
     end
 
     def import
-      ec_key.private_key = BN.new(key, 16)
-      set_public_key
+      @ec_key = OpenSSL::PKey::EC.new(data_sequence.to_der)
+    end
+
+    def data_sequence
+      OpenSSL::ASN1::Sequence([
+        OpenSSL::ASN1::Integer(1),
+        OpenSSL::ASN1::OctetString(OpenSSL::BN.new(key, 16).to_s(2)),
+        OpenSSL::ASN1::ObjectId(GROUP_NAME, 0, :EXPLICIT),
+        OpenSSL::ASN1::BitString(calculate_public_key.to_octet_string(:uncompressed), 1, :EXPLICIT)
+      ])
     end
 
     def calculate_public_key(opts = {})
       opts[:compressed] = true unless opts[:compressed] == false
       group = ec_key.group
       group.point_conversion_form = opts[:compressed] ? :compressed : :uncompressed
-      point = group.generator.mul ec_key.private_key
+      point = group.generator.mul OpenSSL::BN.new(key, 16)
     end
 
     def set_public_key(opts = {})

--- a/lib/money-tree/key.rb
+++ b/lib/money-tree/key.rb
@@ -62,7 +62,7 @@ module MoneyTree
         OpenSSL::ASN1::Integer(1),
         OpenSSL::ASN1::OctetString(OpenSSL::BN.new(key, 16).to_s(2)),
         OpenSSL::ASN1::ObjectId(GROUP_NAME, 0, :EXPLICIT),
-        OpenSSL::ASN1::BitString(calculate_public_key.to_octet_string(:uncompressed), 1, :EXPLICIT)
+        OpenSSL::ASN1::BitString(calculate_public_key.to_octet_string(:uncompressed), 1, :EXPLICIT),
       ])
     end
 

--- a/spec/money-tree/openssl_extensions_spec.rb
+++ b/spec/money-tree/openssl_extensions_spec.rb
@@ -22,8 +22,8 @@ describe MoneyTree::OpenSSLExtensions do
   include MoneyTree::OpenSSLExtensions
 
   context "with inputs" do
-    let(:key1) { OpenSSL::PKey::EC.new("secp256k1").generate_key }
-    let(:key2) { OpenSSL::PKey::EC.new("secp256k1").generate_key }
+    let(:key1) { OpenSSL::PKey::EC.generate("secp256k1") }
+    let(:key2) { OpenSSL::PKey::EC.generate("secp256k1") }
     let(:point_1) { key1.public_key }
     let(:point_2) { key2.public_key }
 


### PR DESCRIPTION
fixes "OpenSSL::PKey::PKeyError: pkeys are immutable on OpenSSL 3.0" Error.
Details: https://github.com/GemHQ/money-tree/issues/63
Although no separate test case have been written, all tests pass OK.
Related to heroku-22 stack.