### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/money-tree.gemspec
+++ b/money-tree.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/GemHQ/money-tree"
   spec.license = "MIT"
 
-  spec.files = `git ls-files`.split($/)
+  spec.files = `git ls-files`.split($/).grep_v(%r{^spec/})
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 41472 bytes
after:  23040 bytes
```